### PR TITLE
Make Data.Array.++.++_index-left signature consistent with ++_index-right

### DIFF
--- a/src/Data/Array.ard
+++ b/src/Data/Array.ard
@@ -89,9 +89,9 @@
       | a :: l, 0 => 0
       | a :: l, suc i => suc (index-left i)
 
-    \func ++_index-left {A : \Type} {l m : Array A} (i : Fin l.len) : (l ++ m) (index-left i) = l i \elim l, i
+    \func ++_index-left {A : \Type} {l m : Array A} {i : Fin l.len} : (l ++ m) (index-left i) = l i \elim l, i
       | a :: l, 0 => idp
-      | a :: l, suc i => ++_index-left i
+      | a :: l, suc i => ++_index-left
 
     \lemma index-left-nat {A : \Type} {l m : Array A} {i : Fin l.len} : index-left {A} {l} {m} i = {Nat} i \elim l, i
       | a :: l, 0 => idp
@@ -132,7 +132,7 @@
       | l :: ls, suc i => index-right (index-big i j)
 
     \func Big++-index {A : \Type} {ls : Array (Array A)} {i : Fin ls.len} {j : Fin (DArray.len {ls i})} : Big (++) nil ls (index-big i j) = ls i j \elim ls, i
-      | ls :: l, 0 => ++_index-left j
+      | ls :: l, 0 => ++_index-left
       | ls :: l, suc i => ++_index-right *> Big++-index
   }
 
@@ -1043,7 +1043,7 @@
 
     \func pairs-index {A B C : \Type} {f : A -> B -> C} {l : Array A} {l' : Array B} (i : Fin l.len) (j : Fin l'.len)
       : \Sigma (k : Fin (DArray.len {pairs f l l'})) (pairs f l l' k = f (l i) (l' j)) \elim l, i
-      | a :: l, 0 => (++.index-left {_} {map (f a) l'} j, ++.++_index-left {_} {map (f a) l'} j)
+      | a :: l, 0 => (++.index-left {_} {map (f a) l'} j, ++.++_index-left {_} {map (f a) l'} {j})
       | a :: l, suc i => \have t => pairs-index i j
                          \in (++.index-right t.1, ++.++_index-right *> t.2)
 


### PR DESCRIPTION
`++_index-right` has last parameter implicit while `++_index-left` has it explicit:

```
\func ++_index-left {A : \Type} {l m : Array A} (i : Fin l.len) : (l ++ m) (index-left i) = l i
\func ++_index-right {A : \Type} {l m : Array A} {i : Fin m.len} : (l ++ m) (index-right i) = m i
```

It becomes slightly annoying when working with both versions at the same time. I thought the implicit variant is more suitable as `++_index-right` is used more often in standard library.

First time contributing here, excuse me if I may not know some nuances